### PR TITLE
Fix vocab upload script

### DIFF
--- a/.github/workflows/push_mrc.yaml
+++ b/.github/workflows/push_mrc.yaml
@@ -1,0 +1,58 @@
+name: Upload data to MRC triplestore
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "jamie/fix-vocab-upload"
+
+jobs:
+  # Detects changes in specific directories
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      data: ${{ steps.filter.outputs.data }}
+      background: ${{ steps.filter.outputs.background }}
+      vocabs: ${{ steps.filter.outputs.vocabs }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          data:
+            - '_background/**'
+            - 'vocabs/**'
+          background:
+            - '_background/**'
+          vocabs:
+            - 'vocabs/**'
+  # Upload files if data has changed
+  upload:
+    needs: changes
+    if: ${{ needs.changes.outputs.data == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      TRIPLESTORE_URL: ${{ secrets.MRC_TRIPLESTORE_URL }}
+      TRIPLESTORE_USERNAME: ${{ secrets.MRC_TRIPLESTORE_USERNAME }}
+      TRIPLESTORE_PASSWORD: ${{ secrets.MRC_TRIPLESTORE_PASSWORD }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          # cache: poetry
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+      # upload background data if changed
+      - name: Upload background
+        if: ${{ needs.changes.outputs.background == 'true' }}
+        run: poetry run python scripts/upload.py --background
+      # upload vocabulary data if changed
+      - name: Upload vocabs
+        if: ${{ needs.changes.outputs.vocabs == 'true' }}
+        run: poetry run python scripts/upload.py

--- a/.github/workflows/push_mrc.yaml
+++ b/.github/workflows/push_mrc.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dorny/paths-filter@v2
-      id: changes
+      id: filter
       with:
         filters: |
           data:
@@ -30,7 +30,7 @@ jobs:
   # Upload files if data has changed
   upload:
     needs: changes
-    if: ${{ needs.changes.outputs.data == 'true' }}
+    # if: ${{ needs.changes.outputs.data == 'true' }}
     runs-on: ubuntu-latest
     env:
       TRIPLESTORE_URL: ${{ secrets.MRC_TRIPLESTORE_URL }}
@@ -50,9 +50,9 @@ jobs:
         run: poetry install --no-interaction --no-root
       # upload background data if changed
       - name: Upload background
-        if: ${{ needs.changes.outputs.background == 'true' }}
+        # if: ${{ needs.changes.outputs.background == 'true' }}
         run: poetry run python scripts/upload.py --background
       # upload vocabulary data if changed
       - name: Upload vocabs
-        if: ${{ needs.changes.outputs.vocabs == 'true' }}
+        # if: ${{ needs.changes.outputs.vocabs == 'true' }}
         run: poetry run python scripts/upload.py

--- a/.github/workflows/push_mrc.yaml
+++ b/.github/workflows/push_mrc.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "jamie/fix-vocab-upload"
+      - "main"
 
 jobs:
   # Detects changes in specific directories
@@ -30,7 +30,7 @@ jobs:
   # Upload files if data has changed
   upload:
     needs: changes
-    # if: ${{ needs.changes.outputs.data == 'true' }}
+    if: ${{ needs.changes.outputs.data == 'true' }}
     runs-on: ubuntu-latest
     env:
       TRIPLESTORE_URL: ${{ secrets.MRC_TRIPLESTORE_URL }}
@@ -50,9 +50,9 @@ jobs:
         run: poetry install --no-interaction --no-root
       # upload background data if changed
       - name: Upload background
-        # if: ${{ needs.changes.outputs.background == 'true' }}
+        if: ${{ needs.changes.outputs.background == 'true' }}
         run: poetry run python scripts/upload.py --background
       # upload vocabulary data if changed
       - name: Upload vocabs
-        # if: ${{ needs.changes.outputs.vocabs == 'true' }}
+        if: ${{ needs.changes.outputs.vocabs == 'true' }}
         run: poetry run python scripts/upload.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea/
 .mypy.ini
+.venv/
+venv/
+__pycache__/
+*.pyc

--- a/vocabs/licenses.ttl
+++ b/vocabs/licenses.ttl
@@ -109,7 +109,7 @@ CC0 (aka CC Zero) is a public dedication tool, which enables creators to give up
     skos:topConceptOf cs: ;
 .
 
-<https://linked.data.gov.au/org/idn> ;
+<https://linked.data.gov.au/org/idn>
     a sdo:Organization ;
     sdo:name "Indigenous Data Network" ;
     sdo:url "https://idnau.org"^^xsd:anyURI ;


### PR DESCRIPTION
Updated the upload script to cater for cases where vocabs were no longer in the repo - i.e. deleted or IRI changed. The script output to terminal now displays similar to git diffs with a symbol prefix per file to make it easier to see what changed, e.g:

```
+ <IRI1> - filename1.ttl
~ <IRI2> - filename2.ttl
- <IRI3>
```
where + means added, ~ means changed (though currently there's no mechanism to detect actual changes, it's just *not* deleted or added) and - means deleted.

A separate workflow file has been added for uploading data to the Fuseki instance running on Melbourne Uni infrastructure.

Also fixed a turtle syntax error in the `licenses.ttl` vocab.