### PR TITLE
Update idn-th.ttl

### DIFF
--- a/vocabs/idn-th.ttl
+++ b/vocabs/idn-th.ttl
@@ -346,7 +346,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:provenance "Taken directly from APAIS online" ;
     rdfs:isDefinedBy <https://vocabularyserver.com/apais/> ;
     skos:broadMatch <https://vocabularyserver.com/apais/xml.php?skosTema=1391> ;
-    skos:broader <https://vocabularyserver.com/apais/xml.php?skosTema=27> ;
+    skos:topConceptOf cs: ;
     skos:definition "Aboriginal men"@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Aboriginal men"@en ;
@@ -428,7 +428,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:provenance "Taken directly from APAIS online" ;
     rdfs:isDefinedBy <https://vocabularyserver.com/apais/> ;
     skos:broadMatch <https://vocabularyserver.com/apais/xml.php?skosTema=2320> ;
-    skos:broader <https://vocabularyserver.com/apais/xml.php?skosTema=27> ;
+    skos:topConceptOf cs: ;
     skos:definition "Aboriginal women"@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Aboriginal women"@en ;
@@ -440,8 +440,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:created "2011-04-29"^^xsd:date ;
     dcterms:provenance "Taken directly from APAIS online" ;
     rdfs:isDefinedBy <https://vocabularyserver.com/apais/> ;
-    skos:broadMatch <https://vocabularyserver.com/apais/xml.php?skosTema=27> ;
-    skos:broader <https://vocabularyserver.com/apais/xml.php?skosTema=2355> ;
+    skos:topConceptOf cs: ;
     skos:definition "Aboriginal youth"@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Aboriginal youth"@en ;
@@ -499,7 +498,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     dcterms:provenance "Taken directly from APAIS online" ;
     rdfs:isDefinedBy <https://vocabularyserver.com/apais/> ;
     skos:broadMatch <https://vocabularyserver.com/apais/xml.php?skosTema=359> ;
-    skos:broader <https://vocabularyserver.com/apais/xml.php?skosTema=27> ;
+    skos:topConceptOf cs: ;
     skos:definition "Aboriginal children"@en ;
     skos:inScheme cs: ;
     skos:prefLabel "Aboriginal children"@en ;
@@ -748,11 +747,6 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
     skos:broader <https://vocabularyserver.com/apais/xml.php?skosTema=1096> ;
     skos:definition "Aborigines"@en ;
     skos:inScheme cs: ;
-    skos:narrower
-        <https://vocabularyserver.com/apais/xml.php?skosTema=17> ,
-        <https://vocabularyserver.com/apais/xml.php?skosTema=25> ,
-        <https://vocabularyserver.com/apais/xml.php?skosTema=26> ,
-        <https://vocabularyserver.com/apais/xml.php?skosTema=6> ;
     skos:prefLabel "Aborigines"@en ;
     skos:related
         <https://vocabularyserver.com/apais/xml.php?skosTema=10> ,


### PR DESCRIPTION
Four concepts were narrower concepts of 'Aboriginies' - these have been promoted to topConcpet of the IDN Themes.

Maybe the broader concept has been deprecated? https://vocabularyserver.com/apais/xml.php?skosTema=27. There are still a number of references to it (e.g. skos:related). When a concept is removed from a concept scheme, any narrow concepts need to be rehoused, or they get orphaned and can't be navigated to (they can still be searched for).